### PR TITLE
make sure the callback when retrieving history only called once

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var events = require('events');
 var util = require('util');
 var async = require('async');
-
+var once = require('once');
 var NobleDevice = require('noble-device');
 
 var LIVE_SERVICE_UUID                       = '39e1fa0084a811e2afba0002a5d5c51b';
@@ -547,7 +547,7 @@ function Upload(fp, callback) {
 
   this.rxStatus = this.RxStatusEnum.STANDBY;
   this.TxStatus = this.TxStatusEnum.IDLE;
-  this.finishCallback = callback;
+  this.finishCallback = once(callback);
 
   this.startUpload(function(err) {
     if (err !== null) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "noble": "^1.0.0"
   },
   "dependencies": {
-    "noble-device": "^1.1.0"
+    "noble-device": "^1.1.0",
+    "once": "^1.3.3"
   }
 }


### PR DESCRIPTION
It you don't disconnect immediately the flower power and you are done with retrieving the history the callback gets called multiple since the `IDLE` state is ticking: https://github.com/oroce/node-flower-power/blob/history-without-noble/index.js#L611

So I added `once` to make sure until you disconnect from the device the callback wont be called multiple times just exactly once.
